### PR TITLE
recommend users to use master branch instead of specific version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Basic:
 ```yaml
 steps:
   - uses: actions/checkout@master
-  - uses: denolib/setup-deno@v1.1.0
+  - uses: denolib/setup-deno@master
     with:
       deno-version: 0.x
   - run: deno run https://deno.land/std/examples/welcome.ts
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Setup Deno
-        uses: denolib/setup-deno@v1.1.0
+        uses: denolib/setup-deno@master
         with:
           deno-version: ${{ matrix.deno }}
       - run: deno run https://deno.land/std/examples/welcome.ts


### PR DESCRIPTION
use `denolib/setup-deno@master` instead of `denolib/setup-deno@v1.1.0`

We should recommend users to use the master branch.

Using a specific version of the branch can cause legacy issues.

eg, we have to continuously update release.json to be compatible with older versions.

**We recommend using the master branch, and promise not make BREAKING CHANGES**