### PR TITLE
Switch default deno version to v1.x

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ author: "The Deno Authors"
 inputs:
   deno-version:
     description: "Version range or exact version of a Deno version to use."
-    default: "v0.x"
+    default: "v1.x"
     required: false
 runs:
   using: "node12"


### PR DESCRIPTION
* Deno v1.0.0 has been released.
* setup-deno should install "v1.x" as default instead of "v0.x".