### PR TITLE
Update installer.ts

### DIFF
--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -37,6 +37,15 @@ describe("installer tests", () => {
     await io.rmRF(tempDir);
   }, 100000);
 
+  it("Acquires version of deno released after Releases.md format changed", async () => {
+    const version = "1.1.1";
+    await installer.getDeno(version);
+    const denoDir = path.join(toolDir, "deno", version, os.arch());
+
+    expect(fs.existsSync(`${denoDir}.complete`)).toBe(true);
+    expect(fs.existsSync(path.join(denoDir, `deno${EXTENSION}`))).toBe(true);
+  }, 100000);
+
   it("Acquires version of deno if no matching version is installed", async () => {
     await installer.getDeno("0.38.0");
     const denoDir = path.join(toolDir, "deno", "0.38.0", os.arch());

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -46,6 +46,13 @@ describe("installer tests", () => {
     expect(fs.existsSync(path.join(denoDir, `deno${EXTENSION}`))).toBe(true);
   }, 100000);
 
+  it("Detects versions of deno released after Releases.md format changed", async () => {
+    expect.assertions(1);
+    const latestVersion = (await installer.getAvailableVersions())[0];
+    if (typeof latestVersion === "string")
+      expect(semver.compare(latestVersion, "1.0.0") > 0).toBe(true);
+  }, 100000);
+
   it("Acquires version of deno if no matching version is installed", async () => {
     await installer.getDeno("0.38.0");
     const denoDir = path.join(toolDir, "deno", "0.38.0", os.arch());

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -129,7 +129,7 @@ export async function getAvailableVersions() {
       "https://raw.githubusercontent.com/denoland/deno/master/Releases.md"
     )
   ).readBody();
-  const matches = body.matchAll(/### (v\d+\.\d+\.\d+)/g);
+  const matches = body.matchAll(/### (v?\d+\.\d+\.\d+)/g);
 
   return [...matches].map(m => m[1]).filter(v => v !== "v0.0.0");
 }


### PR DESCRIPTION
Deno no longer includes a "v" before the version number in `Releases.md`.

In addition to adding test cases, this pull request makes the "v" character optional so the action can set up newer versions of Deno.