### PR TITLE
Cleanup after tests

### DIFF
--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -16,11 +16,13 @@ import * as installer from "../src/installer";
 
 const EXTENSION = process.platform == "win32" ? ".exe" : "";
 
+async function cleanup() {
+  await io.rmRF(path.join(__dirname, "runner"));
+}
+
 describe("installer tests", () => {
-  beforeAll(async () => {
-    await io.rmRF(toolDir);
-    await io.rmRF(tempDir);
-  }, 100000);
+  beforeAll(cleanup, 2000);
+  afterAll(cleanup, 2000);
 
   it("Acquires version of deno released after Releases.md format changed", async () => {
     const version = "1.1.1";

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -3,26 +3,11 @@ import * as path from "path";
 import * as fs from "fs";
 import * as os from "os";
 
-const toolDir = path.join(
-  __dirname,
-  "runner",
-  path.join(
-    Math.random()
-      .toString(36)
-      .substring(7)
-  ),
-  "tools"
-);
-const tempDir = path.join(
-  __dirname,
-  "runner",
-  path.join(
-    Math.random()
-      .toString(36)
-      .substring(7)
-  ),
-  "temp"
-);
+const randomStr = Math.random()
+  .toString(36)
+  .substring(7);
+const toolDir = path.join(__dirname, "runner", randomStr, "tools");
+const tempDir = path.join(__dirname, "runner", randomStr, "temp");
 
 process.env["RUNNER_TOOL_CACHE"] = toolDir;
 process.env["RUNNER_TEMP"] = tempDir;


### PR DESCRIPTION
The files and folders created while running tests were never being deleted.

This isn't a concern for ci, because the entire environment gets blown away after each run, but it is a concern for local test runs, since the runner folder quickly grows very large. We might want to change it to only clear before each run, so we can inspect what was written to disk while debugging. 

Additionally, tests wrote tools and temp to separate random folders, like so:

- runner
  - abcdefg
    - tools
  - hijklm
    - temp

Now, it will write them like so:

- runner
  - abcdefg
    - tools
    - temp

I don't think the random directory is needed at all now, since we're clearing between test case runs, but I can see a world where someone comments out the cleanup code so they can compare output between runs, so I left it.