### PR TITLE
Improve regex

### DIFF
--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -127,7 +127,7 @@ describe("installer tests", () => {
     const versions = await installer.getAvailableVersions();
 
     // the number of versions is increasing
-    expect(versions.length).toBeGreaterThanOrEqual(62);
+    expect(versions.length).toBeGreaterThanOrEqual(88);
 
     for (const v of versions) {
       expect(semver.valid(v)).not.toBeNull();

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -129,9 +129,7 @@ export async function getAvailableVersions() {
       "https://raw.githubusercontent.com/denoland/deno/master/Releases.md"
     )
   ).readBody();
-  const matchIterator = body.matchAll(
-    /### v?(([0-9]+\.){2}([0-9]+)(-[0-9a-zA-Z]+)?)/g
-  );
+  const matchIterator = body.matchAll(/### v?((\d+\.){2}(\d+)(-[\d\w]+)?)/g);
   const matches = [...matchIterator];
   // console.log(matches.map(m => m[1]));
   return matches.map(m => m[1]).filter(v => v !== "0.0.0");

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -129,9 +129,12 @@ export async function getAvailableVersions() {
       "https://raw.githubusercontent.com/denoland/deno/master/Releases.md"
     )
   ).readBody();
-  const matches = body.matchAll(/### (v?\d+\.\d+\.\d+)/g);
-
-  return [...matches].map(m => m[1]).filter(v => v !== "v0.0.0");
+  const matchIterator = body.matchAll(
+    /### v?(([0-9]+\.){2}([0-9]+)(-[0-9a-zA-Z]+)?)/g
+  );
+  const matches = [...matchIterator];
+  // console.log(matches.map(m => m[1]));
+  return matches.map(m => m[1]).filter(v => v !== "0.0.0");
 }
 
 export function getDownloadUrl(version: string): string {


### PR DESCRIPTION
Notable changes to this regex:
- "v" is not included in match[1]. This is to maintain consistency across the output string[]
- regex captures pre-release versions.